### PR TITLE
Ignore the database.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+/config/database.yml

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,28 +1,29 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
 development:
   adapter: postgresql
   hostname: 127.0.0.1
   database: learners_directory
   pool: 5
   timeout: 5000
-  username: nicole
-  password: secret
+  username: fancy_user_name
+  password: fancy_password
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+adapter: postgresql
+  hostname: 127.0.0.1
+  database: learners_directory_test
   pool: 5
   timeout: 5000
+  username: fancy_user_name
+  password: fancy_password
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
+  adapter: postgresql
+  hostname: 127.0.0.1
+  database: learners_directory_production
   pool: 5
   timeout: 5000
+  username: fancy_user_name
+  password: fancy_password


### PR DESCRIPTION
- everyone has their own database.yml e.g. own username/password
  or some don't have a PW at all (for my my user account handles
  that kind of)
- provide a database.yml.example as a guideline that people
  can use
- use postgres for tests and production as well (was sqlite before)
