### PR TITLE
Remove the SQlite gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.0'
 
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
 gem 'pg'
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.7)
     thor (0.18.1)
     thread_safe (0.1.0)
       atomic
@@ -151,6 +150,5 @@ DEPENDENCIES
   rails (= 4.0.0)
   sass-rails (~> 4.0.0)
   sdoc
-  sqlite3
   turbolinks
   uglifier (>= 1.3.0)


### PR DESCRIPTION
- the sqlite gem is not used as we should only be using postgres
  for development, testing and production e.g. unnecessary
  dependency
